### PR TITLE
Persist Android connection mode (VPN/Proxy) across app restarts

### DIFF
--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -24,6 +24,7 @@ class AppState extends ChangeNotifier {
   int _testingFailed = 0;
   String _testUrl = 'https://www.google.com';
   int _proxyPort = StorageService.defaultProxyPort;
+  String _connectionMode = 'vpn';
 
   List<DnsServer> get dnsServers => _dnsServers;
   List<DnsttConfig> get dnsttConfigs => _dnsttConfigs;
@@ -35,6 +36,7 @@ class AppState extends ChangeNotifier {
   bool isDnsBeingTested(String id) => _testingDns[id] ?? false;
   String get testUrl => _testUrl;
   int get proxyPort => _proxyPort;
+  String get connectionMode => _connectionMode;
   int get testingProgress => _testingProgress;
   int get testingTotal => _testingTotal;
   int get testingWorking => _testingWorking;
@@ -66,6 +68,7 @@ class AppState extends ChangeNotifier {
 
     _testUrl = await _storage!.getTestUrl() ?? 'https://www.google.com';
     _proxyPort = await _storage!.getProxyPort();
+    _connectionMode = await _storage!.getConnectionMode() ?? 'vpn';
 
     notifyListeners();
   }
@@ -458,6 +461,13 @@ class AppState extends ChangeNotifier {
   Future<void> setProxyPort(int port) async {
     _proxyPort = port;
     await _storage!.setProxyPort(port);
+    notifyListeners();
+  }
+
+  // Connection Mode (Android: 'vpn' or 'proxy')
+  Future<void> setConnectionMode(String mode) async {
+    _connectionMode = mode;
+    await _storage!.setConnectionMode(mode);
     notifyListeners();
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -28,6 +28,12 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     _vpnService.init();
 
+    // Restore saved connection mode
+    final appState = Provider.of<AppState>(context, listen: false);
+    _connectionMode = appState.connectionMode == 'proxy'
+        ? ConnectionMode.proxy
+        : ConnectionMode.vpn;
+
     // Listen to VPN state changes and update app state accordingly
     _vpnService.stateStream.listen((vpnState) {
       final appState = Provider.of<AppState>(context, listen: false);
@@ -470,7 +476,10 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icons.vpn_key,
             label: 'VPN Mode',
             isSelected: _connectionMode == ConnectionMode.vpn,
-            onTap: () => setState(() => _connectionMode = ConnectionMode.vpn),
+            onTap: () {
+              setState(() => _connectionMode = ConnectionMode.vpn);
+              Provider.of<AppState>(context, listen: false).setConnectionMode('vpn');
+            },
           ),
           const SizedBox(width: 4),
           _buildModeButton(
@@ -478,7 +487,10 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icons.lan,
             label: 'Proxy Mode',
             isSelected: _connectionMode == ConnectionMode.proxy,
-            onTap: () => setState(() => _connectionMode = ConnectionMode.proxy),
+            onTap: () {
+              setState(() => _connectionMode = ConnectionMode.proxy);
+              Provider.of<AppState>(context, listen: false).setConnectionMode('proxy');
+            },
           ),
         ],
       ),

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -10,6 +10,7 @@ class StorageService {
   static const String _activeDnsKey = 'active_dns';
   static const String _testUrlKey = 'test_url';
   static const String _proxyPortKey = 'proxy_port';
+  static const String _connectionModeKey = 'connection_mode';
   static const int defaultProxyPort = 1080;
 
   final SharedPreferences _prefs;
@@ -132,5 +133,14 @@ class StorageService {
 
   Future<void> setProxyPort(int port) async {
     await _prefs.setInt(_proxyPortKey, port);
+  }
+
+  // Connection Mode (Android: 'vpn' or 'proxy')
+  Future<String?> getConnectionMode() async {
+    return _prefs.getString(_connectionModeKey);
+  }
+
+  Future<void> setConnectionMode(String mode) async {
+    await _prefs.setString(_connectionModeKey, mode);
   }
 }


### PR DESCRIPTION
Fixes #7 - The app now remembers the user's last selected connection mode (VPN or Proxy) on Android using SharedPreferences, so it persists when the app is closed and reopened.