### PR TITLE
Improve desktop DNS testing and config management

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
 
     <application
         android:label="DNSTT.XYZ"

--- a/lib/providers/app_state.dart
+++ b/lib/providers/app_state.dart
@@ -96,6 +96,7 @@ class AppState extends ChangeNotifier {
   Future<({int added, int updated})> importDnsServers(List<DnsServer> servers) async {
     int added = 0;
     int updated = 0;
+    final newServers = <DnsServer>[];
 
     for (final server in servers) {
       // Find existing server by IP address
@@ -120,10 +121,15 @@ class AppState extends ChangeNotifier {
           updated++;
         }
       } else {
-        // New server - add it
-        _dnsServers.add(server);
+        // New server - collect for inserting at top
+        newServers.add(server);
         added++;
       }
+    }
+
+    // Insert new servers at the top, preserving their order
+    if (newServers.isNotEmpty) {
+      _dnsServers.insertAll(0, newServers);
     }
 
     await _storage!.saveDnsServers(_dnsServers);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -585,7 +585,7 @@ class _HomeScreenState extends State<HomeScreen> {
         _buildMenuCard(
           context,
           icon: Icons.settings,
-          title: 'DNSTT Configs',
+          title: 'Configs',
           subtitle: '${state.dnsttConfigs.length} configurations',
           onTap: () => Navigator.push(
             context,

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -38,7 +38,7 @@ class StorageService {
   Future<void> addDnsServer(DnsServer server) async {
     final servers = await getDnsServers();
     if (!servers.contains(server)) {
-      servers.add(server);
+      servers.insert(0, server);
       await saveDnsServers(servers);
     }
   }
@@ -73,7 +73,7 @@ class StorageService {
 
   Future<void> addDnsttConfig(DnsttConfig config) async {
     final configs = await getDnsttConfigs();
-    configs.add(config);
+    configs.insert(0, config);
     await saveDnsttConfigs(configs);
   }
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,5 +1,9 @@
 PODS:
+  - file_picker (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -7,20 +11,28 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,9 @@ dependencies:
   uuid: ^4.5.1
   url_launcher: ^6.2.5
   ffi: ^2.1.3
+  file_picker: ^8.0.0
+  share_plus: ^10.0.0
+  socks5_proxy: ^2.1.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  share_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
- Replace raw TCP SOCKS5 handshake with socks5_proxy package for proper HTTPS support on desktop (macOS/Windows/Linux)
- Fix DNS server testing on macOS: unique ports, process cleanup, stderr capture | close #18 
- Add config import/export with file picker and share sheet | close #10 
- Add file-user-selected entitlement for macOS sandbox file operations
- New items appear at top of lists for better UX | close #17 
- Rename "DNSTT Configs" to "Configs" on main screen

