### PR TITLE
Add local DNS auto-detection setting (#13)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:label="DNSTT.XYZ"

--- a/android/app/src/main/kotlin/xyz/dnstt/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/dnstt/app/MainActivity.kt
@@ -19,6 +19,7 @@ import mobile.Mobile
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import android.net.ConnectivityManager
 import android.util.Log
 import java.net.InetSocketAddress
 import java.net.NetworkInterface
@@ -197,6 +198,16 @@ class MainActivity : FlutterActivity() {
                 }
                 "isSlipstreamProxyConnected" -> {
                     result.success(SlipstreamProxyService.isRunning.get())
+                }
+                "getSystemDns" -> {
+                    try {
+                        val cm = getSystemService(android.content.Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                        val lp = cm.getLinkProperties(cm.activeNetwork)
+                        val dns = lp?.dnsServers?.firstOrNull { !it.hostAddress!!.contains(':') }?.hostAddress
+                        result.success(dns)
+                    } catch (e: Exception) {
+                        result.success(null)
+                    }
                 }
                 "testSlipstreamDnsServer" -> {
                     val dnsServer = call.argument<String>("dnsServer") ?: ""

--- a/lib/screens/dns_management_screen.dart
+++ b/lib/screens/dns_management_screen.dart
@@ -121,6 +121,48 @@ class _DnsManagementScreenState extends State<DnsManagementScreen> {
               onChanged: (value) => setState(() => _searchQuery = value),
             ),
           ),
+          // Auto DNS banner
+          Consumer<AppState>(
+            builder: (context, state, _) {
+              if (!state.useAutoDns) return const SizedBox.shrink();
+              return Container(
+                margin: const EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.blue.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.blue.withOpacity(0.3)),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.auto_fix_high, color: Colors.blue[700], size: 20),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Local DNS is enabled (Beta)',
+                            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                          ),
+                          Text(
+                            state.activeDns != null
+                                ? 'Using system DNS: ${state.activeDns!.address}'
+                                : state.autoDnsError ?? 'Detecting...',
+                            style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                          ),
+                        ],
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: () => state.setUseAutoDns(false),
+                      child: const Text('Disable'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
           // Test buttons row with progress
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -313,8 +355,8 @@ class _DnsManagementScreenState extends State<DnsManagementScreen> {
                         contentPadding: const EdgeInsets.only(left: 0, right: 8),
                         leading: Radio<String>(
                           value: server.id,
-                          groupValue: state.activeDns?.id,
-                          onChanged: (_) => state.setActiveDns(server),
+                          groupValue: state.useAutoDns ? null : state.activeDns?.id,
+                          onChanged: state.useAutoDns ? null : (_) => state.setActiveDns(server),
                           activeColor: Colors.green,
                         ),
                         title: Row(
@@ -388,7 +430,7 @@ class _DnsManagementScreenState extends State<DnsManagementScreen> {
                             ),
                           ],
                         ),
-                        onTap: () => state.setActiveDns(server),
+                        onTap: state.useAutoDns ? null : () => state.setActiveDns(server),
                       ),
                     );
                   },

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -11,6 +11,7 @@ class StorageService {
   static const String _testUrlKey = 'test_url';
   static const String _proxyPortKey = 'proxy_port';
   static const String _connectionModeKey = 'connection_mode';
+  static const String _useAutoDnsKey = 'use_auto_dns';
   static const int defaultProxyPort = 1080;
 
   final SharedPreferences _prefs;
@@ -142,5 +143,12 @@ class StorageService {
 
   Future<void> setConnectionMode(String mode) async {
     await _prefs.setString(_connectionModeKey, mode);
+  }
+
+  // Auto DNS
+  Future<bool> getUseAutoDns() async => _prefs.getBool(_useAutoDnsKey) ?? false;
+
+  Future<void> setUseAutoDns(bool value) async {
+    await _prefs.setBool(_useAutoDnsKey, value);
   }
 }

--- a/lib/services/system_dns_service.dart
+++ b/lib/services/system_dns_service.dart
@@ -1,0 +1,132 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+class SystemDnsService {
+  static const _channel = MethodChannel('xyz.dnstt.app/vpn');
+
+  static Future<String?> detectSystemDns() async {
+    try {
+      if (Platform.isAndroid) {
+        return await _detectAndroid();
+      } else if (Platform.isMacOS) {
+        return await _detectMacOS();
+      } else if (Platform.isWindows) {
+        return await _detectWindows();
+      } else if (Platform.isLinux) {
+        return await _detectLinux();
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  static Future<String?> _detectAndroid() async {
+    try {
+      final dns = await _channel.invokeMethod<String>('getSystemDns');
+      return (dns != null && _isValidIp(dns)) ? dns : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<String?> _detectMacOS() async {
+    final result = await Process.run('scutil', ['--dns']);
+    if (result.exitCode != 0) return null;
+
+    final lines = (result.stdout as String).split('\n');
+    for (final line in lines) {
+      final match = RegExp(r'nameserver\[\d+\]\s*:\s*(\S+)').firstMatch(line);
+      if (match != null) {
+        final ip = match.group(1)!;
+        if (_isValidIp(ip)) return ip;
+      }
+    }
+    return null;
+  }
+
+  static Future<String?> _detectWindows() async {
+    // Try PowerShell first
+    try {
+      final result = await Process.run('powershell', [
+        '-Command',
+        'Get-DnsClientServerAddress -AddressFamily IPv4 | Select-Object -ExpandProperty ServerAddresses | Select-Object -First 1',
+      ]);
+      if (result.exitCode == 0) {
+        final ip = (result.stdout as String).trim();
+        if (_isValidIp(ip)) return ip;
+      }
+    } catch (_) {}
+
+    // Fallback to ipconfig
+    try {
+      final result = await Process.run('ipconfig', ['/all']);
+      if (result.exitCode == 0) {
+        final lines = (result.stdout as String).split('\n');
+        for (final line in lines) {
+          if (line.contains('DNS Servers') || line.contains('DNS-Server')) {
+            final match = RegExp(r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})').firstMatch(line);
+            if (match != null) {
+              final ip = match.group(1)!;
+              if (_isValidIp(ip)) return ip;
+            }
+          }
+        }
+      }
+    } catch (_) {}
+
+    return null;
+  }
+
+  static Future<String?> _detectLinux() async {
+    // Try resolvectl first
+    try {
+      final result = await Process.run('resolvectl', ['status']);
+      if (result.exitCode == 0) {
+        final lines = (result.stdout as String).split('\n');
+        bool inDnsSection = false;
+        for (final line in lines) {
+          if (line.contains('DNS Servers:')) {
+            inDnsSection = true;
+            final match = RegExp(r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})').firstMatch(line);
+            if (match != null) {
+              final ip = match.group(1)!;
+              if (_isValidIp(ip) && ip != '127.0.0.53') return ip;
+            }
+            continue;
+          }
+          if (inDnsSection) {
+            final match = RegExp(r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})').firstMatch(line.trim());
+            if (match != null) {
+              final ip = match.group(1)!;
+              if (_isValidIp(ip) && ip != '127.0.0.53') return ip;
+            } else {
+              inDnsSection = false;
+            }
+          }
+        }
+      }
+    } catch (_) {}
+
+    // Fallback to /etc/resolv.conf
+    try {
+      final file = File('/etc/resolv.conf');
+      if (await file.exists()) {
+        final lines = await file.readAsLines();
+        for (final line in lines) {
+          if (line.startsWith('nameserver')) {
+            final match = RegExp(r'nameserver\s+(\S+)').firstMatch(line);
+            if (match != null) {
+              final ip = match.group(1)!;
+              if (_isValidIp(ip) && ip != '127.0.0.53') return ip;
+            }
+          }
+        }
+      }
+    } catch (_) {}
+
+    return null;
+  }
+
+  static bool _isValidIp(String ip) {
+    return RegExp(r'^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$').hasMatch(ip);
+  }
+}


### PR DESCRIPTION
Adds a "Use Local DNS (Beta)" toggle in Settings that detects the system's DNS server from the active network connection. When enabled, the detected DNS is used automatically and manual DNS selection is disabled in the DNS management screen.

Closes #13