### PR TITLE
Fix: kill slipstream-client on app exit

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'providers/app_state.dart';
 import 'services/storage_service.dart';
+import 'services/vpn_service.dart';
 import 'screens/home_screen.dart';
 import 'models/dns_server.dart';
 
@@ -21,6 +23,11 @@ void main() async {
     await appState.addDnsServer(defaultDns);
     await appState.setActiveDns(defaultDns);
   }
+
+  AppLifecycleListener(onExitRequested: () async {
+    VpnService().dispose();
+    return AppExitResponse.exit;
+  });
 
   runApp(
     ChangeNotifierProvider.value(


### PR DESCRIPTION
## Summary

When exiting the desktop client without disconnecting, the app wouldn't kill the background `slipstream-client` process, leading to failures to run the client on next load.

- Add `AppLifecycleListener` in `main.dart` to call `VpnService().dispose()` on app exit, killing the slipstream-client subprocess and cleaning up SSH/DNSTT processes
- Capture stderr from slipstream-client to surface better error messages (e.g. "port already in use" instead of generic "exit code: 1")

## Problem
When the app is quit while a Slipstream connection is active, the slipstream-client subprocess stays alive and holds the listen port. On next launch, `startClient()` fails because the port is in use. It should affect all desktop platforms (macOS, Windows, Linux), but was only tested on a macOS device.

<img width="509" height="71" alt="image" src="https://github.com/user-attachments/assets/051b5543-c619-456d-82cb-aeb8ba804761" />

Root cause: `VpnService.dispose()` already had cleanup logic but nothing called it on app exit.

## Test plan
Tested locally on macOS:
- [ ] Build macOS app, copy slipstream-client + libdnstt.dylib into Frameworks
- [ ] Launch app, connect to a Slipstream config
- [ ] Cmd+Q without disconnecting
- [ ] Verify `lsof -i :1080` shows no stale slipstream-client
- [ ] Relaunch app, connect again — should succeed

Windows and Linux builds need separate verification.