### PR TITLE
fix(android): stabilize DNSTT SSH VPN lifecycle

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,6 +41,10 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# JSch selects crypto implementations with Class.forName. Keep the complete
+# implementation package so R8 does not remove classes such as jce.Random.
+-keep class com.jcraft.jsch.** { *; }
+-dontwarn com.jcraft.jsch.**

--- a/android/app/src/main/kotlin/xyz/dnstt/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/dnstt/app/MainActivity.kt
@@ -35,6 +35,12 @@ class MainActivity : FlutterActivity() {
         const val VPN_STATE_CHANNEL = "xyz.dnstt.app/vpn_state"
         const val VPN_REQUEST_CODE = 1001
         const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1002
+
+        // SSH lives for as long as the app process/foreground VPN service,
+        // not for as long as one FlutterActivity instance.
+        private var sshDnsttClient: mobile.DnsttClient? = null
+        private var sshTunnelClient: SshTunnelClient? = null
+        private val isSshTunnelRunning = AtomicBoolean(false)
     }
 
     private var methodChannel: MethodChannel? = null
@@ -54,12 +60,6 @@ class MainActivity : FlutterActivity() {
 
     // Proxy-only mode (no VPN) - now uses DnsttProxyService
     private val proxyScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    // SSH tunnel mode (DNSTT + SSH dynamic port forwarding)
-    // sshDnsttClient is the internal DNSTT client used by SSH tunnel (runs on port 7001)
-    private var sshDnsttClient: mobile.DnsttClient? = null
-    private var sshTunnelClient: SshTunnelClient? = null
-    private val isSshTunnelRunning = AtomicBoolean(false)
 
     // Proxy sharing mode
     private val isProxySharingEnabled = AtomicBoolean(false)
@@ -233,6 +233,15 @@ class MainActivity : FlutterActivity() {
                         eventSink?.success(state)
                     }
                 }
+                // EventChannel only delivers future events. Emit a snapshot so
+                // a recreated Flutter UI immediately reflects background state.
+                val currentState = when {
+                    isSshTunnelRunning.get() && sshTunnelClient?.isConnected() == true -> "ssh_tunnel_connected"
+                    DnsttProxyService.isRunning.get() || SlipstreamProxyService.isRunning.get() -> "proxy_connected"
+                    DnsttVpnService.isRunning.get() -> "connected"
+                    else -> "disconnected"
+                }
+                events?.success(currentState)
             }
 
             override fun onCancel(arguments: Any?) {
@@ -1190,36 +1199,10 @@ class MainActivity : FlutterActivity() {
     override fun onDestroy() {
         testScope.cancel()
         proxyScope.cancel()
-        // Stop SSH tunnel client if running
-        try {
-            sshTunnelClient?.cleanup()
-            sshTunnelClient = null
-            isSshTunnelRunning.set(false)
-        } catch (e: Exception) {
-            Log.e("DnsttSsh", "Error stopping SSH tunnel on destroy: ${e.message}")
-        }
-        // Stop proxy service if running
-        if (DnsttProxyService.isRunning.get()) {
-            try {
-                val serviceIntent = Intent(this, DnsttProxyService::class.java).apply {
-                    action = DnsttProxyService.ACTION_DISCONNECT
-                }
-                startService(serviceIntent)
-            } catch (e: Exception) {
-                Log.e("DnsttProxy", "Error stopping proxy service on destroy: ${e.message}")
-            }
-        }
-        // Stop slipstream proxy service if running
-        if (SlipstreamProxyService.isRunning.get()) {
-            try {
-                val serviceIntent = Intent(this, SlipstreamProxyService::class.java).apply {
-                    action = SlipstreamProxyService.ACTION_DISCONNECT
-                }
-                startService(serviceIntent)
-            } catch (e: Exception) {
-                Log.e("SlipstreamProxy", "Error stopping slipstream proxy on destroy: ${e.message}")
-            }
-        }
+        // Do not stop SSH here. Activity destruction is a UI lifecycle event;
+        // the foreground VPN service and its tunnel must keep running.
+        // Proxy foreground services are also independent of the activity and
+        // must only stop after an explicit disconnect action.
         DnsttProxyService.stateCallback = null
         SlipstreamProxyService.stateCallback = null
         methodChannel?.setMethodCallHandler(null)

--- a/android/app/src/main/kotlin/xyz/dnstt/app/SshTunnelClient.kt
+++ b/android/app/src/main/kotlin/xyz/dnstt/app/SshTunnelClient.kt
@@ -31,8 +31,8 @@ class SshTunnelClient {
         private const val DNSTT_TUNNEL_HOST = "127.0.0.1"
         private const val DNSTT_TUNNEL_PORT = 7001
 
-        // SOCKS5 proxy output port (same as other modes)
-        private const val SOCKS5_PROXY_PORT = 1080
+        // DnsttVpnService consumes the SSH SOCKS5 proxy on this port.
+        private const val SOCKS5_PROXY_PORT = 7000
     }
 
     private var session: Session? = null

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -19,13 +20,16 @@ class HomeScreen extends StatefulWidget {
 
 enum ConnectionMode { vpn, proxy }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   final VpnService _vpnService = VpnService();
   ConnectionMode _connectionMode = ConnectionMode.vpn;
+  StreamSubscription<VpnState>? _stateSubscription;
+  bool _isReconcilingState = false;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _vpnService.init();
 
     // Restore saved connection mode
@@ -35,7 +39,8 @@ class _HomeScreenState extends State<HomeScreen> {
         : ConnectionMode.vpn;
 
     // Listen to VPN state changes and update app state accordingly
-    _vpnService.stateStream.listen((vpnState) {
+    _stateSubscription = _vpnService.stateStream.listen((vpnState) {
+      if (!mounted) return;
       final appState = Provider.of<AppState>(context, listen: false);
       switch (vpnState) {
         case VpnState.connecting:
@@ -49,19 +54,67 @@ class _HomeScreenState extends State<HomeScreen> {
           appState.setConnectionStatus(ConnectionStatus.disconnected);
           break;
         case VpnState.error:
-          appState.setConnectionStatus(ConnectionStatus.error, 'VPN connection failed');
+          appState.setConnectionStatus(
+            ConnectionStatus.error,
+            'VPN connection failed',
+          );
           break;
       }
     });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _reconcileConnectionState();
+    });
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _reconcileConnectionState();
+    }
+  }
+
+  Future<void> _reconcileConnectionState() async {
+    if (_isReconcilingState || !mounted) return;
+    _isReconcilingState = true;
+    try {
+      final vpnState = await _vpnService.refreshConnectionState();
+      if (!mounted) return;
+      final appState = Provider.of<AppState>(context, listen: false);
+      switch (vpnState) {
+        case VpnState.connected:
+          appState.setConnectionStatus(ConnectionStatus.connected);
+          break;
+        case VpnState.connecting:
+          appState.setConnectionStatus(ConnectionStatus.connecting);
+          break;
+        case VpnState.error:
+          appState.setConnectionStatus(
+            ConnectionStatus.error,
+            _vpnService.lastError ?? 'VPN connection failed',
+          );
+          break;
+        case VpnState.disconnected:
+        case VpnState.disconnecting:
+          appState.setConnectionStatus(ConnectionStatus.disconnected);
+          break;
+      }
+    } finally {
+      _isReconcilingState = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _stateSubscription?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('DNSTT.XYZ'),
-        centerTitle: true,
-      ),
+      appBar: AppBar(title: const Text('DNSTT.XYZ'), centerTitle: true),
       body: Consumer<AppState>(
         builder: (context, state, _) {
           return SingleChildScrollView(
@@ -112,17 +165,17 @@ class _HomeScreenState extends State<HomeScreen> {
           const SizedBox(height: 12),
           Text(
             'Local Proxy Address:',
-            style: TextStyle(
-              fontSize: 12,
-              color: Colors.grey[600],
-            ),
+            style: TextStyle(fontSize: 12, color: Colors.grey[600]),
           ),
           const SizedBox(height: 4),
           Row(
             children: [
               Expanded(
                 child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(6),
@@ -145,9 +198,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 child: InkWell(
                   borderRadius: BorderRadius.circular(6),
                   onTap: () {
-                    Clipboard.setData(ClipboardData(
-                      text: proxyAddress,
-                    ));
+                    Clipboard.setData(ClipboardData(text: proxyAddress));
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         content: Text('Address copied!'),
@@ -169,7 +220,7 @@ class _HomeScreenState extends State<HomeScreen> {
             child: ElevatedButton.icon(
               onPressed: () async {
                 final telegramUrl = Uri.parse(
-                  'tg://socks?server=127.0.0.1&port=$proxyPort'
+                  'tg://socks?server=127.0.0.1&port=$proxyPort',
                 );
                 if (await canLaunchUrl(telegramUrl)) {
                   await launchUrl(telegramUrl);
@@ -177,7 +228,9 @@ class _HomeScreenState extends State<HomeScreen> {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
-                        content: Text('Telegram is not installed or cannot open the link'),
+                        content: Text(
+                          'Telegram is not installed or cannot open the link',
+                        ),
                         backgroundColor: Colors.orange,
                       ),
                     );
@@ -204,7 +257,8 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget _buildVpnConnectionCard(BuildContext context, AppState state) {
     final isConnected = state.connectionStatus == ConnectionStatus.connected;
     final isConnecting = state.connectionStatus == ConnectionStatus.connecting;
-    final isDisconnected = state.connectionStatus == ConnectionStatus.disconnected;
+    final isDisconnected =
+        state.connectionStatus == ConnectionStatus.disconnected;
     final isError = state.connectionStatus == ConnectionStatus.error;
     final canConnect = state.activeConfig != null && state.activeDns != null;
 
@@ -247,13 +301,19 @@ class _HomeScreenState extends State<HomeScreen> {
                   color: isConnected
                       ? Colors.green
                       : isConnecting
-                          ? Colors.orange
-                          : isError
-                              ? Colors.red[700]
-                              : (canConnect ? Colors.grey[700] : Colors.grey[400]),
+                      ? Colors.orange
+                      : isError
+                      ? Colors.red[700]
+                      : (canConnect ? Colors.grey[700] : Colors.grey[400]),
                   boxShadow: [
                     BoxShadow(
-                      color: (isConnected ? Colors.green : isConnecting ? Colors.orange : Colors.grey).withOpacity(0.3),
+                      color:
+                          (isConnected
+                                  ? Colors.green
+                                  : isConnecting
+                                  ? Colors.orange
+                                  : Colors.grey)
+                              .withOpacity(0.3),
                       blurRadius: 20,
                       spreadRadius: 5,
                     ),
@@ -261,11 +321,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 child: Center(
                   child: isConnecting
-                      ? const Icon(
-                          Icons.close,
-                          size: 60,
-                          color: Colors.white,
-                        )
+                      ? const Icon(Icons.close, size: 60, color: Colors.white)
                       : Icon(
                           isError ? Icons.refresh : Icons.power_settings_new,
                           size: 60,
@@ -295,8 +351,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 Text(
                   statusText,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ],
             ),
@@ -362,7 +418,10 @@ class _HomeScreenState extends State<HomeScreen> {
                     style: TextStyle(color: Colors.grey[600], fontSize: 14),
                   ),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 4,
+                    ),
                     decoration: BoxDecoration(
                       color: state.activeConfig!.tunnelType == TunnelType.ssh
                           ? Colors.purple[100]
@@ -370,7 +429,9 @@ class _HomeScreenState extends State<HomeScreen> {
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
-                      state.activeConfig!.tunnelType == TunnelType.ssh ? 'SSH' : 'Socks',
+                      state.activeConfig!.tunnelType == TunnelType.ssh
+                          ? 'SSH'
+                          : 'Socks',
                       style: TextStyle(
                         fontSize: 12,
                         fontWeight: FontWeight.bold,
@@ -382,7 +443,10 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 4,
+                    ),
                     decoration: BoxDecoration(
                       color: state.activeConfig!.isSlipstream
                           ? Colors.orange[100]
@@ -436,10 +500,7 @@ class _HomeScreenState extends State<HomeScreen> {
               const SizedBox(height: 16),
               Text(
                 'Select a config and DNS server to connect',
-                style: TextStyle(
-                  color: Colors.grey[600],
-                  fontSize: 12,
-                ),
+                style: TextStyle(color: Colors.grey[600], fontSize: 12),
                 textAlign: TextAlign.center,
               ),
             ],
@@ -451,7 +512,11 @@ class _HomeScreenState extends State<HomeScreen> {
             ],
 
             // Show proxy notice when connected in proxy mode (desktop or Android proxy mode)
-            if (isConnected && (VpnService.isDesktopPlatform || _vpnService.isProxyMode || (_vpnService.isSshTunnelMode && _connectionMode == ConnectionMode.proxy))) ...[
+            if (isConnected &&
+                (VpnService.isDesktopPlatform ||
+                    _vpnService.isProxyMode ||
+                    (_vpnService.isSshTunnelMode &&
+                        _connectionMode == ConnectionMode.proxy))) ...[
               const SizedBox(height: 16),
               const Divider(),
               const SizedBox(height: 12),
@@ -480,7 +545,10 @@ class _HomeScreenState extends State<HomeScreen> {
             isSelected: _connectionMode == ConnectionMode.vpn,
             onTap: () {
               setState(() => _connectionMode = ConnectionMode.vpn);
-              Provider.of<AppState>(context, listen: false).setConnectionMode('vpn');
+              Provider.of<AppState>(
+                context,
+                listen: false,
+              ).setConnectionMode('vpn');
             },
           ),
           const SizedBox(width: 4),
@@ -491,7 +559,10 @@ class _HomeScreenState extends State<HomeScreen> {
             isSelected: _connectionMode == ConnectionMode.proxy,
             onTap: () {
               setState(() => _connectionMode = ConnectionMode.proxy);
-              Provider.of<AppState>(context, listen: false).setConnectionMode('proxy');
+              Provider.of<AppState>(
+                context,
+                listen: false,
+              ).setConnectionMode('proxy');
             },
           ),
         ],
@@ -561,10 +632,7 @@ class _HomeScreenState extends State<HomeScreen> {
         const SizedBox(width: 8),
         Text(
           '$label: ',
-          style: TextStyle(
-            color: Colors.grey[600],
-            fontSize: 14,
-          ),
+          style: TextStyle(color: Colors.grey[600], fontSize: 14),
         ),
         Expanded(
           child: Text(
@@ -625,9 +693,9 @@ class _HomeScreenState extends State<HomeScreen> {
           title: 'Support Us',
           subtitle: 'Donate to help improve the app',
           onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const DonateScreen()),
-              ),
+            context,
+            MaterialPageRoute(builder: (_) => const DonateScreen()),
+          ),
           color: Colors.red,
         ),
         const SizedBox(height: 12),
@@ -699,10 +767,7 @@ class _HomeScreenState extends State<HomeScreen> {
               const SizedBox(height: 8),
               Text(
                 'Note: Change takes effect on next connection.',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Colors.grey[600],
-                ),
+                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
               ),
               const Divider(),
               const SizedBox(height: 8),
@@ -774,13 +839,28 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _connect(BuildContext context, AppState state) async {
+    // Native services may have remained connected while the Flutter activity
+    // was backgrounded or recreated. Never start a second tunnel on top of it.
+    final actualState = await _vpnService.refreshConnectionState();
+    if (actualState == VpnState.connected) {
+      state.setConnectionStatus(ConnectionStatus.connected);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Connection is already active')),
+        );
+      }
+      return;
+    }
+
     if (state.useAutoDns) {
       await state.refreshAutoDns();
       if (state.activeDns == null) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(state.autoDnsError ?? 'Could not detect system DNS'),
+              content: Text(
+                state.autoDnsError ?? 'Could not detect system DNS',
+              ),
               backgroundColor: Colors.red,
             ),
           );
@@ -792,7 +872,9 @@ class _HomeScreenState extends State<HomeScreen> {
     final isDesktop = VpnService.isDesktopPlatform;
     final isSshTunnel = state.activeConfig?.tunnelType == TunnelType.ssh;
     final isSlipstream = state.activeConfig?.isSlipstream ?? false;
-    final useProxyMode = isDesktop || (Platform.isAndroid && _connectionMode == ConnectionMode.proxy);
+    final useProxyMode =
+        isDesktop ||
+        (Platform.isAndroid && _connectionMode == ConnectionMode.proxy);
 
     // Determine connection type for permission and messages
     String connectionType;
@@ -800,7 +882,9 @@ class _HomeScreenState extends State<HomeScreen> {
     if (isSshTunnel) {
       connectionType = useProxyMode ? 'SSH tunnel (proxy)' : 'SSH tunnel (VPN)';
     } else {
-      connectionType = useProxyMode ? '$protocolName proxy' : '$protocolName VPN';
+      connectionType = useProxyMode
+          ? '$protocolName proxy'
+          : '$protocolName VPN';
     }
 
     // Validate SSH settings if SSH tunnel type
@@ -810,7 +894,9 @@ class _HomeScreenState extends State<HomeScreen> {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
-              content: Text('SSH username is required. Please configure in settings.'),
+              content: Text(
+                'SSH username is required. Please configure in settings.',
+              ),
               backgroundColor: Colors.red,
             ),
           );
@@ -919,11 +1005,13 @@ class _HomeScreenState extends State<HomeScreen> {
       if (success) {
         String successMessage;
         if (isSshTunnel && useProxyMode) {
-          successMessage = 'SSH tunnel (proxy) started on ${_vpnService.socksProxyAddress}';
+          successMessage =
+              'SSH tunnel (proxy) started on ${_vpnService.socksProxyAddress}';
         } else if (isSshTunnel && !useProxyMode) {
           successMessage = 'SSH tunnel (VPN) connected';
         } else if (useProxyMode || isDesktop) {
-          successMessage = '$protocolName proxy started on ${_vpnService.socksProxyAddress}';
+          successMessage =
+              '$protocolName proxy started on ${_vpnService.socksProxyAddress}';
         } else {
           successMessage = '$protocolName VPN connected';
         }
@@ -937,9 +1025,11 @@ class _HomeScreenState extends State<HomeScreen> {
         final error = _vpnService.lastError;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(error != null
-                ? 'Failed to start $connectionType: $error'
-                : 'Failed to start $connectionType'),
+            content: Text(
+              error != null
+                  ? 'Failed to start $connectionType: $error'
+                  : 'Failed to start $connectionType',
+            ),
             backgroundColor: Colors.red,
           ),
         );
@@ -969,9 +1059,9 @@ class _HomeScreenState extends State<HomeScreen> {
       } else {
         disconnectMessage = 'VPN disconnected';
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(disconnectMessage)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(disconnectMessage)));
     }
   }
 
@@ -986,9 +1076,9 @@ class _HomeScreenState extends State<HomeScreen> {
     state.setConnectionStatus(ConnectionStatus.disconnected);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Connection cancelled')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Connection cancelled')));
     }
   }
 }

--- a/lib/services/vpn_service.dart
+++ b/lib/services/vpn_service.dart
@@ -5,17 +5,13 @@ import 'dnstt_ffi_service.dart';
 import 'slipstream_service.dart';
 import '../models/dnstt_config.dart';
 
-enum VpnState {
-  disconnected,
-  connecting,
-  connected,
-  disconnecting,
-  error,
-}
+enum VpnState { disconnected, connecting, connected, disconnecting, error }
 
 class VpnService {
   static const MethodChannel _channel = MethodChannel('xyz.dnstt.app/vpn');
-  static const EventChannel _stateChannel = EventChannel('xyz.dnstt.app/vpn_state');
+  static const EventChannel _stateChannel = EventChannel(
+    'xyz.dnstt.app/vpn_state',
+  );
 
   static final VpnService _instance = VpnService._internal();
   factory VpnService() => _instance;
@@ -270,7 +266,9 @@ class VpnService {
 
       // Read server greeting response (2 bytes)
       final authResponse = await readBytes(2);
-      if (authResponse.length < 2 || authResponse[0] != 0x05 || authResponse[1] != 0x00) {
+      if (authResponse.length < 2 ||
+          authResponse[0] != 0x05 ||
+          authResponse[1] != 0x00) {
         socket.destroy();
         print('SOCKS5 auth failed');
         return false;
@@ -281,7 +279,10 @@ class VpnService {
       const targetHost = 'api.ipify.org';
       const targetPort = 80;
       final connectRequest = <int>[
-        0x05, 0x01, 0x00, 0x03,
+        0x05,
+        0x01,
+        0x00,
+        0x03,
         targetHost.length,
         ...targetHost.codeUnits,
         (targetPort >> 8) & 0xFF,
@@ -321,7 +322,8 @@ class VpnService {
       allBytes.removeRange(0, extraBytes);
 
       // Send HTTP request
-      const httpRequest = 'GET /?format=text HTTP/1.1\r\nHost: $targetHost\r\nConnection: close\r\n\r\n';
+      const httpRequest =
+          'GET /?format=text HTTP/1.1\r\nHost: $targetHost\r\nConnection: close\r\n\r\n';
       socket.add(httpRequest.codeUnits);
       await socket.flush();
 
@@ -592,14 +594,15 @@ class VpnService {
     }
 
     try {
-      final result = await _channel.invokeMethod<bool>('connectSlipstreamProxy', {
-        'dnsServer': dnsServer,
-        'tunnelDomain': tunnelDomain,
-        'proxyPort': proxyPort,
-        'congestionControl': congestionControl,
-        'keepAliveInterval': keepAliveInterval,
-        'gso': gso,
-      });
+      final result = await _channel
+          .invokeMethod<bool>('connectSlipstreamProxy', {
+            'dnsServer': dnsServer,
+            'tunnelDomain': tunnelDomain,
+            'proxyPort': proxyPort,
+            'congestionControl': congestionControl,
+            'keepAliveInterval': keepAliveInterval,
+            'gso': gso,
+          });
 
       if (result == true) {
         _currentState = VpnState.connected;
@@ -649,8 +652,12 @@ class VpnService {
       // Stop VPN service
       await _channel.invokeMethod<bool>('disconnect');
       // Also stop any proxy services that might still be running
-      try { await _channel.invokeMethod<bool>('disconnectProxy'); } on PlatformException catch (_) {}
-      try { await _channel.invokeMethod<bool>('disconnectSlipstreamProxy'); } on PlatformException catch (_) {}
+      try {
+        await _channel.invokeMethod<bool>('disconnectProxy');
+      } on PlatformException catch (_) {}
+      try {
+        await _channel.invokeMethod<bool>('disconnectSlipstreamProxy');
+      } on PlatformException catch (_) {}
       _currentState = VpnState.disconnected;
       _connectedDns = null;
       _connectedDomain = null;
@@ -769,35 +776,52 @@ class VpnService {
       // The SSH server address should be the actual server hostname/IP that the DNSTT server forwards to
       // Since DNSTT tunnel forwards to the same server running SSH, we connect to localhost:22 through the proxy
       final proxyCommand = 'nc -X 5 -x 127.0.0.1:7001 %h %p';
-      print('Starting SSH tunnel: ssh -D $bindAddress -o ProxyCommand="$proxyCommand" $sshUsername@localhost');
+      print(
+        'Starting SSH tunnel: ssh -D $bindAddress -o ProxyCommand="$proxyCommand" $sshUsername@localhost',
+      );
 
       if (sshPassword != null && sshPassword.isNotEmpty) {
         // Try using sshpass if available
         final sshpassCheck = await Process.run('which', ['sshpass']);
         if (sshpassCheck.exitCode == 0) {
           _sshProcess = await Process.start('sshpass', [
-            '-p', sshPassword,
+            '-p',
+            sshPassword,
             'ssh',
-            '-D', bindAddress,
-            '-o', 'ProxyCommand=$proxyCommand',
-            '-o', 'StrictHostKeyChecking=no',
-            '-o', 'UserKnownHostsFile=/dev/null',
-            '-o', 'ServerAliveInterval=15',
-            '-o', 'ServerAliveCountMax=3',
+            '-D',
+            bindAddress,
+            '-o',
+            'ProxyCommand=$proxyCommand',
+            '-o',
+            'StrictHostKeyChecking=no',
+            '-o',
+            'UserKnownHostsFile=/dev/null',
+            '-o',
+            'ServerAliveInterval=15',
+            '-o',
+            'ServerAliveCountMax=3',
             '-N',
             '$sshUsername@localhost',
           ]);
         } else {
           // No sshpass, use expect-style approach with stdin
           _sshProcess = await Process.start('ssh', [
-            '-D', bindAddress,
-            '-o', 'ProxyCommand=$proxyCommand',
-            '-o', 'StrictHostKeyChecking=no',
-            '-o', 'UserKnownHostsFile=/dev/null',
-            '-o', 'ServerAliveInterval=15',
-            '-o', 'ServerAliveCountMax=3',
-            '-o', 'PreferredAuthentications=password',
-            '-o', 'PubkeyAuthentication=no',
+            '-D',
+            bindAddress,
+            '-o',
+            'ProxyCommand=$proxyCommand',
+            '-o',
+            'StrictHostKeyChecking=no',
+            '-o',
+            'UserKnownHostsFile=/dev/null',
+            '-o',
+            'ServerAliveInterval=15',
+            '-o',
+            'ServerAliveCountMax=3',
+            '-o',
+            'PreferredAuthentications=password',
+            '-o',
+            'PubkeyAuthentication=no',
             '-N',
             '$sshUsername@localhost',
           ]);
@@ -818,12 +842,18 @@ class VpnService {
       } else {
         // No password, try key-based auth
         _sshProcess = await Process.start('ssh', [
-          '-D', bindAddress,
-          '-o', 'ProxyCommand=$proxyCommand',
-          '-o', 'StrictHostKeyChecking=no',
-          '-o', 'UserKnownHostsFile=/dev/null',
-          '-o', 'ServerAliveInterval=15',
-          '-o', 'ServerAliveCountMax=3',
+          '-D',
+          bindAddress,
+          '-o',
+          'ProxyCommand=$proxyCommand',
+          '-o',
+          'StrictHostKeyChecking=no',
+          '-o',
+          'UserKnownHostsFile=/dev/null',
+          '-o',
+          'ServerAliveInterval=15',
+          '-o',
+          'ServerAliveCountMax=3',
           '-N',
           '$sshUsername@localhost',
         ]);
@@ -837,7 +867,9 @@ class VpnService {
           _currentState = VpnState.error;
           _isSshTunnelMode = false;
           _stateController.add(_currentState);
-          try { ffi.stop(); } catch (_) {}
+          try {
+            ffi.stop();
+          } catch (_) {}
         }
       });
 
@@ -1039,6 +1071,20 @@ class VpnService {
     }
   }
 
+  Future<bool> isSlipstreamProxyConnected() async {
+    if (_isDesktop || !_platformSupported) return false;
+    try {
+      final result = await _channel.invokeMethod<bool>(
+        'isSlipstreamProxyConnected',
+      );
+      return result ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
   /// Connect SSH tunnel over DNSTT
   /// Flow: DNSTT tunnel -> SSH client -> SSH dynamic port forwarding -> local SOCKS5 proxy on configured port
   Future<bool> connectSshTunnel({
@@ -1227,7 +1273,9 @@ class VpnService {
   /// Check if SSH tunnel is running
   Future<bool> isSshTunnelConnected() async {
     if (_isDesktop) {
-      return _currentState == VpnState.connected && _isSshTunnelMode && _sshProcess != null;
+      return _currentState == VpnState.connected &&
+          _isSshTunnelMode &&
+          _sshProcess != null;
     }
 
     if (!_platformSupported) {
@@ -1270,6 +1318,38 @@ class VpnService {
     } on PlatformException {
       return false;
     }
+  }
+
+  /// Reconcile cached Flutter state with the native background services.
+  /// This is required when the activity resumes or is recreated while a
+  /// foreground VPN/proxy service is still alive.
+  Future<VpnState> refreshConnectionState() async {
+    if (_isDesktop) return _currentState;
+
+    final sshConnected = await isSshTunnelConnected();
+    final slipstreamProxyConnected = sshConnected
+        ? false
+        : await isSlipstreamProxyConnected();
+    final proxyConnected = sshConnected || slipstreamProxyConnected
+        ? false
+        : await isProxyConnected();
+    final vpnConnected = await isConnected();
+
+    _isSshTunnelMode = sshConnected;
+    _isProxyMode =
+        !sshConnected && (proxyConnected || slipstreamProxyConnected);
+    _activeTransport = slipstreamProxyConnected
+        ? TransportType.slipstream
+        : (proxyConnected ? TransportType.dnstt : _activeTransport);
+    _currentState =
+        (sshConnected ||
+            proxyConnected ||
+            slipstreamProxyConnected ||
+            vpnConnected)
+        ? VpnState.connected
+        : VpnState.disconnected;
+    _stateController.add(_currentState);
+    return _currentState;
   }
 
   String? get connectedDns => _connectedDns;
@@ -1359,15 +1439,16 @@ class VpnService {
     if (!_platformSupported) return -1;
 
     try {
-      final result = await _channel.invokeMethod<int>('testSlipstreamDnsServer', {
-        'dnsServer': dnsServer,
-        'tunnelDomain': tunnelDomain,
-        'testUrl': testUrl,
-        'timeoutMs': timeoutMs,
-        'congestionControl': congestionControl,
-        'keepAliveInterval': keepAliveInterval,
-        'gso': gso,
-      });
+      final result = await _channel
+          .invokeMethod<int>('testSlipstreamDnsServer', {
+            'dnsServer': dnsServer,
+            'tunnelDomain': tunnelDomain,
+            'testUrl': testUrl,
+            'timeoutMs': timeoutMs,
+            'congestionControl': congestionControl,
+            'keepAliveInterval': keepAliveInterval,
+            'gso': gso,
+          });
       return result ?? -1;
     } on MissingPluginException {
       return -1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dnstt_xyz_app
 description: "DNSTT Client - DNS Tunnel Mobile App"
 publish_to: 'none'
 
-version: 2.2.0+5
+version: 2.2.0+2009
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
## What changed

Fixed several Android issues with DNSTT + SSH:

- Fixed missing JSch classes in release builds.
- Changed the SSH SOCKS port from `1080` to `7000` to match the VPN service.
- Fixed the UI showing `Disconnected` after returning to the app.
- Prevented duplicate connections and port conflicts.
- Kept SSH and proxy services running when the Activity is recreated.
- Fixed state restoration for DNSTT and Slipstream proxy modes.

Tested on Android 8.0: connection survives backgrounding and Activity recreation, and the UI correctly shows `Connected`.